### PR TITLE
Fixes implementation of cart sum refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Let's implement our refactor:
 
 ```ruby
 def checkout
-  total = shopping_cart.sum
+  total = shopping_cart.sum { |item| item.price }
 
   ...
 end


### PR DESCRIPTION
Fixes #1 

Thanks for flagging this error @Leepzig - you're correct, the `.sum` method wouldn't work as originally implemented in the readme. In order to use `.sum` with an array of objects, it's necessary to use a block that returns a numerical value.